### PR TITLE
Standardize task naming and fix double-templated lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An [Ansible](https://www.ansible.com) role that on first contact with a host wil
 <a href="https://app.codacy.com/gh/dgibbs64/ansible-role-first_contact"><img src="https://img.shields.io/codacy/grade/1a892d499efd4dabb73beffa8d64ed01?logo=codacy&style=flat-square" alt="Codacy grade"></a>
 <a href="https://github.com/dgibbs64/ansible-role-first_contact/actions/workflows/action-molecule.yml"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/dgibbs64/ansible-role-first_contact/action-molecule.yml?label=molecule&logo=ansible&style=flat-square"></a>
 <a href="https://galaxy.ansible.com/dgibbs64/first_contact"><img alt="GitHub tag (latest by date)" src="https://img.shields.io/github/v/tag/dgibbs64/ansible-role-first_contact?color=EE0000&label=release&logo=ansible&style=flat-square"></a>
-<a href="https://github.com/dgibbs64/ansible-role-first_contact/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/gameservermanagers/docker-steamcmd?style=flat-square" alt="MIT License"></a>
+<a href="https://github.com/dgibbs64/ansible-role-first_contact/blob/main/LICENSE.md"><img src="https://img.shields.io/github/license/dgibbs64/ansible-role-first_contact?style=flat-square" alt="MIT License"></a>
 </p>
 
 ## About
@@ -71,7 +71,6 @@ The following distribution families and versions are currently supported and tes
 ## Role Variables
 
 ```yaml
----
 ---
 # defaults file for first_contact
 

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,61 +1,61 @@
 ---
-- name: "Test if first_contact_ssh_bypass_host_identity_check is set correctly"
+- name: "Test that first_contact_ssh_bypass_host_identity_check is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_ssh_bypass_host_identity_check is defined
       - first_contact_ssh_bypass_host_identity_check is boolean
     quiet: true
 
-- name: "Test if first_contact_ssh_bypass_host_key_check is set correctly"
+- name: "Test that first_contact_ssh_bypass_host_key_check is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_ssh_bypass_host_key_check is defined
       - first_contact_ssh_bypass_host_key_check is boolean
     quiet: true
 
-- name: "Test if first_contact_ssh_connection_timeout is set correctly"
+- name: "Test that first_contact_ssh_connection_timeout is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_ssh_connection_timeout is defined
       - first_contact_ssh_connection_timeout is integer
     quiet: true
 
-- name: "Test if first_contact_root_shell is set correctly"
+- name: "Test that first_contact_root_shell is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_root_shell is defined
       - first_contact_root_shell is string
     quiet: true
 
-- name: "Test if first_contact_deploy_password_update is set correctly"
+- name: "Test that first_contact_deploy_password_update is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_deploy_password_update is defined
       - first_contact_deploy_password_update is string
     quiet: true
 
-- name: "Test if first_contact_ssh_password_disable is set correctly"
+- name: "Test that first_contact_ssh_password_disable is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_ssh_password_disable is defined
       - first_contact_ssh_password_disable is boolean
     quiet: true
 
-- name: "Test if first_contact_ssh_private_key_file is set correctly"
+- name: "Test that first_contact_ssh_private_key_file is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_ssh_private_key_file is defined
       - first_contact_ssh_private_key_file is string
     quiet: true
 
-- name: "Test if first_contact_ssh_public_key_file is set correctly"
+- name: "Test that first_contact_ssh_public_key_file is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_ssh_public_key_file is defined
       - first_contact_ssh_public_key_file is string
     quiet: true
 
-- name: "Test if first_contact_initial_fallback_user is set correctly"
+- name: "Test that first_contact_initial_fallback_user is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_initial_fallback_user is defined
@@ -63,7 +63,7 @@
       - (first_contact_initial_fallback_user | length) > 0
     quiet: true
 
-- name: "Test if first_contact_remove_initial_fallback_user is set correctly"
+- name: "Test that first_contact_remove_initial_fallback_user is set correctly"
   ansible.builtin.assert:
     that:
       - first_contact_remove_initial_fallback_user is defined

--- a/tasks/first_contact.yml
+++ b/tasks/first_contact.yml
@@ -1,9 +1,9 @@
 ---
 # First contact is for hosts that require the deploy user setup.
-- name: "SSH key check"
+- name: "Initial SSH key check"
   ansible.builtin.include_tasks: ssh_key_check.yml
 
-- name: "Test connection for root user"
+- name: "Attempt connection as root, falling back to initial user if unreachable"
   block:
     - name: "Test connection for root user"
       remote_user: "root"
@@ -30,7 +30,7 @@
       ansible.posix.authorized_key:
         user: "root"
         state: present
-        key: "{{ lookup('file', '{{ first_contact_ssh_public_key_file }}') }}"
+        key: "{{ lookup('file', first_contact_ssh_public_key_file) }}"
       when: ssh_public_key_file_stat.stat.exists
 
     - name: "Ensure SSH root login is enabled"
@@ -83,7 +83,7 @@
 - name: "Configure ansible deploy user: {{ first_contact_deploy_user }}"
   remote_user: "root"
   block:
-    - name: "SSH key check"
+    - name: "SSH key check for ansible deploy user"
       ansible.builtin.include_tasks: ssh_key_check.yml
 
     - name: "Generate a random password: {{ first_contact_deploy_user }}"
@@ -103,7 +103,7 @@
       ansible.posix.authorized_key:
         user: "{{ first_contact_deploy_user }}"
         state: present
-        key: "{{ lookup('file', '{{ first_contact_ssh_public_key_file }}') }}"
+        key: "{{ lookup('file', first_contact_ssh_public_key_file) }}"
       when: ssh_public_key_file_stat.stat.exists
 
     - name: "Ensure ansible deploy user is added to sudoers: {{ first_contact_deploy_user }}"

--- a/tasks/root_user.yml
+++ b/tasks/root_user.yml
@@ -20,7 +20,7 @@
   ansible.posix.authorized_key:
     user: "root"
     state: present
-    key: "{{ lookup('file', '{{ first_contact_ssh_public_key_file }}') }}"
+    key: "{{ lookup('file', first_contact_ssh_public_key_file) }}"
   register: ssh_key_copied
   when: ssh_public_key_file_stat.stat.exists and first_contact_root_add_ssh_key is true
 

--- a/tasks/second_contact.yml
+++ b/tasks/second_contact.yml
@@ -22,7 +22,7 @@
       ansible.builtin.set_fact:
         python_not_installed: true
 
-- name: "Bootstrap"
+- name: "Bootstrap if python is missing"
   when: python3_not_installed is defined and python_not_installed is defined
   block:
     - name: "Bootstrap"
@@ -56,7 +56,7 @@
       ansible.posix.authorized_key:
         user: "{{ first_contact_deploy_user }}"
         state: present
-        key: "{{ lookup('file', '{{ first_contact_ssh_public_key_file }}') }}"
+        key: "{{ lookup('file', first_contact_ssh_public_key_file) }}"
       register: ssh_key_copied
       when: ssh_public_key_file_stat.stat.exists
 
@@ -65,7 +65,7 @@
       ansible.builtin.fail:
         msg: "Failed to configure ansible deploy user on second contact: {{ first_contact_deploy_user }}"
 
-- name: "Bootstrap"
+- name: "Bootstrap after SSH key rotation"
   become: true
   ansible.builtin.import_role:
     name: robertdebock.bootstrap

--- a/tasks/tests.yml
+++ b/tasks/tests.yml
@@ -1,12 +1,12 @@
 ---
 - name: "Test connection"
   block:
-    - name: "Test connection for ansible deploy user: {{ first_contact_deploy_user }}"
+    - name: "Test connection for ansible deploy user (initial check): {{ first_contact_deploy_user }}"
       remote_user: "{{ first_contact_deploy_user }}"
       ansible.builtin.wait_for_connection:
         timeout: "{{ first_contact_ssh_connection_timeout }}"
 
-    - name: "Test sudo access for ansible deploy: {{ first_contact_deploy_user }}"
+    - name: "Test sudo access for ansible deploy user (initial check): {{ first_contact_deploy_user }}"
       ansible.builtin.raw: sudo -n id -u
       changed_when: false
       register: deploy_user_sudo_check
@@ -17,7 +17,7 @@
           'PAM account management error' in (deploy_user_sudo_check.stderr | default(''))
         )
 
-    - name: "Notice sudo PAM limitation in container"
+    - name: "Notice sudo PAM limitation in container (initial check)"
       ansible.builtin.debug:
         msg: "Skipping sudo-dependent checks due to container PAM limitation"
       when:
@@ -35,12 +35,12 @@
 
 - name: "Test first_contact_deploy_user is accessible"
   block:
-    - name: "Test connection for ansible deploy user: {{ first_contact_deploy_user }}"
+    - name: "Test connection for ansible deploy user (post-configuration check): {{ first_contact_deploy_user }}"
       remote_user: "{{ first_contact_deploy_user }}"
       ansible.builtin.wait_for_connection:
         timeout: "{{ first_contact_ssh_connection_timeout }}"
 
-    - name: "Test sudo access for ansible deploy: {{ first_contact_deploy_user }}"
+    - name: "Test sudo access for ansible deploy user (post-configuration check): {{ first_contact_deploy_user }}"
       ansible.builtin.raw: sudo -n id -u
       changed_when: false
       register: deploy_user_sudo_check
@@ -51,7 +51,7 @@
           'PAM account management error' in (deploy_user_sudo_check.stderr | default(''))
         )
 
-    - name: "Notice sudo PAM limitation in container"
+    - name: "Notice sudo PAM limitation in container (post-configuration check)"
       ansible.builtin.debug:
         msg: "Skipping sudo-dependent checks due to container PAM limitation"
       when:


### PR DESCRIPTION
## Summary
### Naming
- assert.yml: 10 tasks changed from "Test if X is set correctly" to "Test that X is set correctly", matching the convention used in netdata/linux_admin_packages/postfix_send_only_relay
- Disambiguated repeated task names within the same file (ambiguous in logs / with `--start-at-task`):
  - first_contact.yml: "SSH key check" used twice for two different includes; block/task name collision on "Test connection for root user"
  - tests.yml: two blocks used identical task names for connection/sudo/PAM-notice checks
  - second_contact.yml: "Bootstrap" reused for both the outer block and inner task in two different places

### Bug fix
- first_contact.yml (x2), root_user.yml, second_contact.yml: fixed a double-templated lookup - `lookup(\x27file\x27, \x27{{ first_contact_ssh_public_key_file }}\x27)` wraps an already-Jinja-templated outer string around a second Jinja expression. It happens to work because Ansible double-templates strings, but it is non-idiomatic and inconsistent with the rest of the codebase. Simplified to `lookup(\x27file\x27, first_contact_ssh_public_key_file)`.

### Docs
- README.md: removed a duplicated `---` in the Role Variables code fence (copy-paste artifact from defaults/main.yml)
- README.md: license badge image was pointing at `gameservermanagers/docker-steamcmd` instead of this repo - fixed

No functional changes other than the lookup() fix, which is behavior-preserving.